### PR TITLE
Show off cool Vue thing

### DIFF
--- a/src/js/components/Machine.vue
+++ b/src/js/components/Machine.vue
@@ -121,11 +121,11 @@ export default {
     }
   },
   components: {
-    'play-icon': PlayIcon,
-    'mute-icon': MuteIcon,
-    'add-icon': AddIcon,
-    'remove-icon': RemoveIcon,
-    'settings-icon': SettingsIcon
+    PlayIcon,
+    MuteIcon,
+    AddIcon,
+    RemoveIcon,
+    SettingsIcon
   },
   methods: {
     audioContextCheck() {


### PR DESCRIPTION
ES6 ensures `{ Thing }` becomes `{ Thing: Thing }` and Vue ensures `{ FooBar }` becomes `{ 'foo-bar': FooBar }`. Tidy.